### PR TITLE
Altered add-card param type, and added printing of warning message when 'err' is empty

### DIFF
--- a/src/commands/add-card.js
+++ b/src/commands/add-card.js
@@ -7,7 +7,7 @@ var __ = function(program, output, logger, config, trello, translator){
     "title": {
       position: 1,
       help: "The card's title",
-      list: true,
+      list: false,
       required: true
     },
     "description": {
@@ -48,7 +48,11 @@ var __ = function(program, output, logger, config, trello, translator){
 
     trello.post("/1/cards", params, function(err, data){
       if (err){ throw err; }
-      logger.info("Card created");
+      if (data == "invalid value for name") {
+        logger.warning("Invalid value for card name");
+      } else {
+        logger.info("Card created");
+      }
     });
 
   });


### PR DESCRIPTION
I couldn't get `add-card` to work unless `list` was set to false.  But in addition, when it was set to true, the callback was returning that error message as part of the `data` with `err` null, hence the explicit check.