### PR TITLE
Implemented Trello's add-list command

### DIFF
--- a/src/commands/add-board.js
+++ b/src/commands/add-board.js
@@ -2,62 +2,75 @@
 
 var __ = function (program, output, logger, config, trello, translator, trelloApiCommands) {
 
-  program
-  .command("add-board")
-  .help("Adds a new board with the specified name")
-  .options({
-    "boardName": {
-      abbr: 'b',
-      metavar: 'BOARD',
-      help: "The name of the new board",
-      required: true
-    },
-    "description": {
-      abbr: 'd',
-      metavar: 'DESC',
-      help: "The description of the board",
-      required: false
-    },
-    "cardAging": {
-      abbr: 'a',
-      help: "Turns card aging on for the new board (default is off)",
-      required: false,
-      flag: true
-    },
-    "cardCoverImages": {
-      abbr: 'c',
-      help: "Turns off the showing of images on the front of cards (default is on)",
-      required: false,
-      flag: true
-    },
-    "verbose": {
-      abbr: 'v',
-      help: "Turn on increased error reporting",
-      required: false,
-      flag: true
-    }
-  })
-  .callback(function (opts) {
-    logger.info("Adding new board");
+    var trelloApiCommand = {};
 
-    // Build up arguments to send
-    var params = {
-      "name": opts.boardName,
-      "desc": opts.description,
-      "prefs_cardCovers" : opts.cardCoverImages ? "false" : "true",
-      "prefs_cardAging" : opts.cardAging ? "pirate" : "regular"
+    trelloApiCommand.makeTrelloApiCall = function (options, onComplete) {
+        logger.info("Adding new board...");
+
+        // Build up arguments to send
+        var params = {
+            "name": options.boardName,
+            "desc": options.description ? options.description : "",
+            "prefs_cardCovers" : options.cardCoverImages ? "false" : "true",
+            "prefs_cardAging" : options.cardAging ? "pirate" : "regular"
+        };
+
+        // console.log(params);
+
+        trello.post("/1/boards", params, function (err, data) {
+            if (err) {
+                throw err;
+            }
+            // console.log(data);
+            logger.info("Board added, new URL: " + data.url);
+
+            trelloApiCommands["refresh"].makeTrelloApiCall(null, onComplete);
+        });
     };
 
-    trello.post("/1/boards", params, function (err, data) {
-      if (err) {
-        throw err;
-      }
+    trelloApiCommand.nomnomProgramCall = function () {
+        program
+            .command("add-board")
+            .help("Adds a new board with the specified name")
+            .options({
+                "boardName": {
+                    abbr: 'b',
+                    metavar: 'BOARD',
+                    help: "The name of the new board",
+                    required: true
+                },
+                "description": {
+                    abbr: 'd',
+                    metavar: 'DESC',
+                    help: "The description of the board",
+                    required: false
+                },
+                "cardAging": {
+                    abbr: 'a',
+                    help: "Turns card aging on for the new board (default is off)",
+                    required: false,
+                    flag: true
+                },
+                "cardCoverImages": {
+                    abbr: 'c',
+                    help: "Turns off the showing of images on the front of cards (default is on)",
+                    required: false,
+                    flag: true
+                },
+                "verbose": {
+                    abbr: 'v',
+                    help: "Turn on increased error reporting",
+                    required: false,
+                    flag: true
+                }
+                })
+            .callback(function (options) {
+                trelloApiCommand.makeTrelloApiCall(options);
+            });
 
-      logger.info("Board added, new URL: " + data.url);
+    };
 
-      trelloApiCommands["refresh"].makeTrelloApiCall(null);
-    });
-
-  });
+    return trelloApiCommand;
 }
+
 module.exports = __;

--- a/src/commands/add-list.js
+++ b/src/commands/add-list.js
@@ -1,0 +1,102 @@
+"use strict";
+
+var __ = function (program, output, logger, config, trello, translator, trelloApiCommands) {
+
+    var trelloApiCommand = {};
+
+    trelloApiCommand.makeTrelloApiCall = function (options, onComplete) {
+
+        logger.info("Adding new list...");
+
+        // find board ID
+        var boardId;
+
+        try {
+            boardId = translator.getBoardIdByName(options.boardName);
+        } catch (err) {
+            if (err.message == "Unknown Board") {
+                if (options.force && !options.triedCreate) {
+                    logger.info("Board doesn't exist, creating...");
+                    options.triedCreate = true;
+                    trelloApiCommands["add-board"].makeTrelloApiCall(options, function () { trelloApiCommands["add-list"].makeTrelloApiCall(options, null); });
+                    return;
+                } else {
+                    logger.error("Board '" + options.boardName + "' does not exist.  Exitting.");
+                    process.exit(1);
+                }
+            } else {
+                log.error("Unknown error:");
+                throw err;
+            }
+        }
+        boardId = translator.getBoardIdByName(options.boardName);
+
+        // Build up arguments to send
+        var params = {
+            "name": options.listName,
+            "idBoard": boardId,
+            "pos" : ['top', 'bottom'].indexOf(options.position) > -1 ? options.position : "top"
+        };
+
+        trello.post("/1/lists", params, function (err, data) {
+            if (err) {
+                throw err;
+            }
+
+            if (options.verbose) {
+                logger.warning(data);
+            }
+
+            logger.info("List added, new ID: " + data.id);
+
+            trelloApiCommands["refresh"].makeTrelloApiCall(null);
+        });
+    };
+
+
+    trelloApiCommand.nomnomProgramCall = function () {
+
+        program
+            .command("add-list")
+            .help("Adds a new list to the spcified board with the specified name")
+            .options({
+                "boardName": {
+                      abbr: 'b',
+                      metavar: 'BOARD',
+                      help: "The name of the board to add the list to",
+                      required: true
+                },
+                "listName": {
+                      abbr: 'l',
+                      metavar: 'LIST',
+                      help: "The name of the new list",
+                      required: true
+                },
+                "position": {
+                      abbr: 'p',
+                      metavar: 'POS',
+                      help: "The position of the new list: acceptable values are 'top' or 'bottom' (default: top)",
+                      required: false
+                },
+                "force": {
+                      abbr: 'f',
+                      help: "Force - will creae the board if it doesn't already exist",
+                      flag: true,
+                      required: false
+                },
+                "verbose": {
+                      abbr: 'v',
+                      help: "Turn on increased error reporting",
+                      required: false,
+                      flag: true
+                }
+            })
+            .callback(function (options) {
+                trelloApiCommand.makeTrelloApiCall(options);
+            });
+    };
+
+    return trelloApiCommand;
+}
+
+module.exports = __;

--- a/src/commands/refresh.js
+++ b/src/commands/refresh.js
@@ -8,12 +8,9 @@ var ___ = function (program, output, logger, config, trello, translator) {
 
     var trelloApiCommand = {};
 
-    trelloApiCommand.makeTrelloApiCall = function (options) {
-        // SJK: type is an object of options; it will never be a string
-        // Defaults!
-        // if (typeof type != "string"){
+    trelloApiCommand.makeTrelloApiCall = function (options, onComplete) {
+
         var type = "all";
-        // }
 
         var cachePath = config.get("configPath") + config.get("translationCache");
         var cacheFile = {};
@@ -50,7 +47,6 @@ var ___ = function (program, output, logger, config, trello, translator) {
                 // Write it back to the cache file
                 fs.writeFileSync(cachePath, JSON.stringify(cacheFile));
 
-                // bug here: this isn't waiting for the above callback to return, and that means that it misses the results from any new boards just added.
                 if (type == 'lists' || type == 'all') {
                   async.each(Object.keys(cacheFile.translations.boards), function(board, callback){
                     trello.get("/1/boards/"+board+"/lists", function(err, data) {
@@ -67,10 +63,17 @@ var ___ = function (program, output, logger, config, trello, translator) {
                     fs.writeFileSync(cachePath, JSON.stringify(cacheFile));
                   });
 
+                  translator.reloadTranslations();
+
                   output.normal("Organisation, board and list cache refreshed");
+
+                  if (typeof onComplete == 'function') {
+                      onComplete();
+                  }
                 }
             });
         }
+
     };
 
     trelloApiCommand.nomnomProgramCall = function () {

--- a/src/translator.js
+++ b/src/translator.js
@@ -22,6 +22,24 @@ var Translator = function(logger, config){
   this.cache = cacheFile;
 }
 
+Translator.prototype.reloadTranslations = function () {
+    // Load the cache file
+    var cachePath = this.config.get("configPath") + this.config.get("translationCache");
+    var cacheFile = {};
+    try {
+      cacheFile = JSON.parse(fs.readFileSync(cachePath));
+    } catch (e){
+      // Nothing
+    }
+
+    cacheFile.translations = cacheFile.translations || {};
+    cacheFile.translations.orgs = cacheFile.translations.orgs || {};
+    cacheFile.translations.boards = cacheFile.translations.boards || {};
+    cacheFile.translations.lists = cacheFile.translations.lists || {};
+
+    this.cache = cacheFile;
+};
+
 Translator.prototype.getOrganisation = function(id){
   this.logger.debug("Looking up organisation: " + id);
   var item = this.cache.translations.orgs[id];


### PR DESCRIPTION
* Converted `add-board.js` to use new format (making it callable from other API comands).
* Implemented `add-list.js`, which has a `-force` option that will create the board if it doesn't already exist.
* Altered structure of new `trelloApiCommand` object to allow a callback to be given for running on completion.
* Altered `translator.js` to provide a `reloadTranslations` method that will update the cache in memory, for running after the `refresh` API call.

