### PR TITLE
Adds show-boards command; makes 'show-list' friendlier

### DIFF
--- a/src/commands/refresh.js
+++ b/src/commands/refresh.js
@@ -41,8 +41,8 @@ var ___ = function (program, output, logger, config, trello, translator) {
         if (type == 'lists' || type == 'boards' || type == 'all') {
             trello.get("/1/members/me/boards", function(err, data) {
                 if (err) throw err;
-                _.each(data, function(item){
-                    cacheFile.translations.boards[item.id] = [item.idOrganization, item.name];
+                _.each(data, function(item) {
+                    cacheFile.translations.boards[item.id] = [item.idOrganization, item.name, item.closed];
                 });
 
                 // Write it back to the cache file

--- a/src/commands/show-boards.js
+++ b/src/commands/show-boards.js
@@ -1,0 +1,57 @@
+"use strict";
+
+var _ = require("underscore");
+
+var __ = function (program, output, logger, config, trello, translator, trelloApiCommands) {
+
+    var trelloApiCommand = {};
+
+    trelloApiCommand.makeTrelloApiCall = function (options, onComplete) {
+
+        var listOfBoards = [];
+
+        _.each(translator.cache.translations.boards, function (oneBoard, boardId) {
+            if (boardId != "undefined" && (oneBoard.length == 2 || oneBoard.length == 3 && options.includeClosed ? true : oneBoard[2] == false)) {
+                // oneBoard: [ organisationId, boardName, closed (not guaranteed available) ]
+                listOfBoards.splice(
+                    _.sortedIndex(listOfBoards, { id : boardId, name : oneBoard[1], closed : oneBoard[2] }, 'name'),
+                    0,
+                    { id : boardId, name : oneBoard[1], closed : oneBoard[2] });
+            }
+        });
+
+        _.each(listOfBoards, function printBoardObject(board) {
+            output.normal(board.name + (options.hideIds ? "" : (" (ID: " + board.id + ")")));
+        });
+    };
+
+
+    trelloApiCommand.nomnomProgramCall = function () {
+        program
+            .command("show-boards")
+            .help("Show the list of cached boards")
+            .options({
+                "includeClosed": {
+                      abbr: 'c',
+                      help: "Include closed boards in the list (default: no)",
+                      required: false,
+                      flag: true,
+                      default: false
+                },
+                "hideIds": {
+                      abbr: 'i',
+                      help: "Do not include the board IDs in the output (default is to print IDs)",
+                      required: false,
+                      flag: true,
+                      default: false
+                }
+            })
+            .callback(function (options) {
+                trelloApiCommand.makeTrelloApiCall(options);
+            });
+    };
+
+    return trelloApiCommand;
+}
+
+module.exports = __;

--- a/src/commands/show-cards.js
+++ b/src/commands/show-cards.js
@@ -1,0 +1,64 @@
+"use strict";
+
+fs = require("fs");
+
+var __ = function(program, output, logger, config, trello, translator, trelloApiCommands) {
+
+    var trelloApiCommand = {};
+
+    trelloApiCommand.makeTrelloApiCall = function (options, onComplete) {
+        logger.info("Showing cards belonging to the specified list");
+
+        // Grab our boards etc
+        try {
+            var boardId = translator.getBoardIdByName(options.board);
+        } catch (err) {
+            if (err.message == "Unknown Board") {
+                logger.warning("Unknown board.  Perhaps you have a typo?");
+
+                output.normal("\nYou have the following open boards:\n");
+                trelloApiCommands["show-boards"].makeTrelloApiCall({ includeClosed : false, hideIds : true}, null);
+                return;
+            }
+        }
+        var listId = translator.getListIdByBoardNameAndListName(options.board, options.list);
+
+        trello.get("/1/lists/" + listId + "", {"cards": "open"}, function(err, data) {
+            if (err) throw err;
+
+            if (data.cards.length > 0) {
+                output.normal(translator.getBoard(data.cards[0].idBoard).underline);
+            }
+            for (var i in data.cards) {
+                var formattedCardName = data.cards[i].name.replace(/\n/g, "");
+                output.normal("* " + formattedCardName);
+            }
+        });
+    }
+
+    trelloApiCommand.nomnomProgramCall = function () {
+        program
+            .command("show-cards")
+            .help("Show the cards on a list")
+            .options({
+                "board": {
+                    abbr: 'b',
+                    metavar: 'BOARD',
+                    help: "The board name which contains the list of cards to show",
+                    required: true
+                },
+                "list": {
+                    abbr: 'l',
+                    metavar: 'LIST',
+                    help: "The name of the list whose cards to show",
+                    required: true
+                }
+            })
+            .callback(function (options) {
+                trelloApiCommand.makeTrelloApiCall(options);
+            });
+        }
+
+    return trelloApiCommand;
+}
+module.exports = __;

--- a/src/commands/show-list.js
+++ b/src/commands/show-list.js
@@ -1,49 +1,38 @@
-fs = require("fs");
+"use strict";
 
-var __ = function(program, output, logger, config, trello, translator){
+var __ = function(program, output, logger, config, trello, translator, trelloApiCommands) {
 
-  program
-  .command("show-list")
-  .options({
-   "board": {
-      abbr: 'b',
-      metavar: 'BOARD',
-      help: "The board name to add a card to",
-      required: true
-    },
-    "list": {
-      abbr: 'l',
-      metavar: 'LIST',
-      help: "The list name to add a card to",
-      required: true
+    var trelloApiCommand = {};
+
+    trelloApiCommand.makeTrelloApiCall = function (options, onComplete) {
+
+        trelloApiCommands["show-cards"].makeTrelloApiCall(options, onComplete);
+
     }
-  })
-  .help("Show cards on a list")
-  .callback(function(opts){
 
-    logger.info("Showing assigned cards");
-
-    // Grab our boards etc
-    var boardId = translator.getBoardIdByName(opts.board);
-    var listId = translator.getListIdByBoardNameAndListName(opts.board, opts.list);
-
-    trello.get("/1/lists/" + listId + "", {"cards": "open"}, function(err, data) {
-      if (err) throw err;
-
-      // Order the issues by board
-      var cards = {};
-      for (var i in data.cards){
-        var item = data.cards[i];
-        cards[item.idBoard] = cards[item.idBoard] || [];
-        cards[item.idBoard].push(item.name.replace(/\n/g, ""));
-      }
-
-      for (var j in cards){
-        output.normal(translator.getBoard(j).underline);
-        for (var k in cards[j]){
-          output.normal("* " + cards[j][k]);
+    trelloApiCommand.nomnomProgramCall = function () {
+        program
+            .command("show-list")
+            .help("DEPRECATED.  Show cards on a list (use 'show-cards' instead; command retained for backwards compatibility)")
+            .options({
+                "board": {
+                    abbr: 'b',
+                    metavar: 'BOARD',
+                    help: "The board name which contains the list to show",
+                    required: true
+                },
+                "list": {
+                    abbr: 'l',
+                    metavar: 'LIST',
+                    help: "The name of the list whose cards to show",
+                    required: true
+                }
+            })
+            .callback(function (options) {
+                trelloApiCommand.makeTrelloApiCall(options);
+            });
         }
-      }});
-  });
+
+    return trelloApiCommand;
 }
 module.exports = __;

--- a/src/translator.js
+++ b/src/translator.js
@@ -74,8 +74,8 @@ Translator.prototype.getBoardIdByName = function(name) {
   name = name.toLowerCase();
   this.logger.debug("Looking up board by name: " + name);
   var boards = this.cache.translations.boards;
-  for (var i in boards){
-    if (boards[i][1].toLowerCase() == name){
+  for (var i in boards) {
+    if (boards[i][1] != null && boards[i][1].toLowerCase() == name){
       return i;
     }
   }


### PR DESCRIPTION
This branch makes the following additions:

* Implements a `show-boards` command, which will print a list of boards (optionally including closed boards, and with or without IDs)

It makes the following changes:

* `show-list` command is renamed to `show-cards`, which is what it actually does (`show-list` is retained as operational command so as not to break user scripts)
* the `translator` now stores the closed status of boards.
* if the `show-cards` (previously: `show-list`) command is given an unknown board name, then it suggests that the user might've mistyped it, and prints a list of known, open boards.
* the `translator`'s `getBoardIdByName()` is made more robust by checking whether the board name is in null prior to calling `toLowerCase()`