### PR TITLE
Show list name in addition to board name when listing cards

### DIFF
--- a/src/commands/show-cards.js
+++ b/src/commands/show-cards.js
@@ -27,7 +27,11 @@ var __ = function(program, output, logger, config, trello, translator, trelloApi
             if (err) throw err;
 
             if (data.cards.length > 0) {
-                output.normal(translator.getList(data.cards[0].idList).underline);
+                if (options.showListName) {
+                  output.normal(translator.getList(data.cards[0].idList).underline);
+                } else {
+                  output.normal(translator.getBoard(data.cards[0].idBoard).underline);
+                }
             }
             for (var i in data.cards) {
                 var formattedCardName = data.cards[i].name.replace(/\n/g, "");
@@ -52,6 +56,13 @@ var __ = function(program, output, logger, config, trello, translator, trelloApi
                     metavar: 'LIST',
                     help: "The name of the list whose cards to show",
                     required: true
+                },
+                "showListName": {
+                      abbr: 'n',
+                      help: "Show list name in title, in addtion to board name",
+                      required: false,
+                      flag: true,
+                      default: false
                 }
             })
             .callback(function (options) {

--- a/src/commands/show-cards.js
+++ b/src/commands/show-cards.js
@@ -27,7 +27,7 @@ var __ = function(program, output, logger, config, trello, translator, trelloApi
             if (err) throw err;
 
             if (data.cards.length > 0) {
-                output.normal(translator.getBoard(data.cards[0].idBoard).underline);
+                output.normal(translator.getList(data.cards[0].idList).underline);
             }
             for (var i in data.cards) {
                 var formattedCardName = data.cards[i].name.replace(/\n/g, "");

--- a/src/commands/show-labels.js
+++ b/src/commands/show-labels.js
@@ -1,0 +1,81 @@
+"use strict";
+
+fs = require("fs");
+
+var __ = function(program, output, logger, config, trello, translator, trelloApiCommands) {
+
+    var trelloApiCommand = {};
+
+    trelloApiCommand.makeTrelloApiCall = function (options, onComplete) {
+        logger.info("Showing labels belonging to the specified board");
+
+        // Grab our boards etc
+        try {
+            var boardId = translator.getBoardIdByName(options.board);
+        } catch (err) {
+            if (err.message == "Unknown Board") {
+                logger.warning("Unknown board.  Perhaps you have a typo?");
+
+                output.normal("\nYou have the following open boards:\n");
+                trelloApiCommands["show-boards"].makeTrelloApiCall({ includeClosed : false, hideIds : true}, null);
+                return;
+            }
+        }
+
+        trello.get("/1/boards/" + boardId + "/labels", function(err, data) {
+            if (err) throw err;
+
+            for (var i in data) {
+              var formattedLabel = data[i].color;
+
+              if (data[i].name.length > 0) {
+                formattedLabel += ' (' + data[i].name + ')';
+              }
+
+              if (options.showUses) {
+                formattedLabel += ', ' + data[i].uses;
+              }
+
+              if (options.showIds) {
+                formattedLabel += ' (ID: ' + data[i].id + ')';
+              }
+
+              output.normal(formattedLabel);
+            }
+        });
+    }
+
+    trelloApiCommand.nomnomProgramCall = function () {
+        program
+            .command("show-labels")
+            .help("Show labels defined on a board")
+            .options({
+                "board": {
+                    abbr: 'b',
+                    metavar: 'BOARD',
+                    help: "The board name which contains the labels to show",
+                    required: true
+                },
+                "showIds": {
+                      abbr: 'i',
+                      help: "Show label IDs in the output (default is to omit IDs)",
+                      required: false,
+                      flag: true,
+                      default: false
+                },
+                "showUses": {
+                      abbr: 'u',
+                      help: "Show how many times a label has been used",
+                      required: false,
+                      flag: true,
+                      default: false
+                }
+            })
+            .callback(function (options) {
+                trelloApiCommand.makeTrelloApiCall(options);
+            });
+        }
+
+    return trelloApiCommand;
+}
+module.exports = __;

--- a/src/translator.js
+++ b/src/translator.js
@@ -68,6 +68,19 @@ Translator.prototype.getBoard = function(id){
   return str || "Board: " + id;
 }
 
+Translator.prototype.getList = function(id){
+  this.logger.debug("Looking up list: " + id);
+  var item = this.cache.translations.lists[id];
+  var str = "";
+  if (item){
+    if (item[0]){
+      str += this.getBoard(item[0]) + " > ";
+    }
+    str += item[1];
+  }
+  return str || "List: " + id;
+}
+
 Translator.prototype.getBoardIdByName = function(name) {
   // console.log("-- getBoardIdByName() boards length: " + Object.keys(this.cache.translations.boards).length);
   // console.log("-- getBoardIdByName() lists length: " + Object.keys(this.cache.translations.lists).length);


### PR DESCRIPTION
When getting cards from multiple lists within the same board, they all had the same title; that is, the board name.  I would have liked to see the list title, as well.  This PR will show the list title in addition to the board name.