### PR TITLE
Added commands/features and little adjustments.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,4 @@ You will then have the `trello` command available anywhere.
 
     # Move all cards:
     $ trello move-all-cards -b "GTD" -l "Completed next actions" -c "GTD" -d "Completed next actions (Nov 2-8)"
+#mg foo

--- a/README.md
+++ b/README.md
@@ -21,11 +21,15 @@ trello-cli currently supports the following commands:
 	add-card           Add a card to a board
 	add-list           Adds a new list to the spcified board with the specified name
 	assigned-to-me     Show cards that are currently assigned to you
-    close-board        Closes those board(s) where the specified text occurs in their name
+	close-board        Closes those board(s) where the specified text occurs in their name
 	delete-card        Remove a card from a board
 	move-all-cards     Move all cards from one list to another
 	refresh            Refresh all your board/list names
-	show-list          Show cards on a list
+	show-boards        Show the list of cached boards
+	show-cards         Show the cards on a list
+	show-labels        Show labels defined on a board
+	show-list          DEPRECATED.  Show cards on a list (use 'show-cards' instead; command retained for backwards compatibility)
+	show-lists         Show the list of cached lists
 
 # On Windows
 
@@ -44,4 +48,4 @@ You will then have the `trello` command available anywhere.
 
     # Move all cards:
     $ trello move-all-cards -b "GTD" -l "Completed next actions" -c "GTD" -d "Completed next actions (Nov 2-8)"
-#mg foo
+

--- a/bin/trello
+++ b/bin/trello
@@ -62,7 +62,7 @@ if (process.argv[2] == 'set-auth'){
 
 // Handle the case when there's no command
 program.nocommand().callback(function(){
-  output.emphasis("Trello CLI");
+  output.underline("Trello CLI");
   output.normal("Welcome to Trello CLI! To get started, run:");
   output.normal("trello --help");
 });

--- a/config.json.dist
+++ b/config.json.dist
@@ -1,6 +1,0 @@
-{
-  "appKey": "<KEY>",
-  "configPath": "/home/michael/.trello-cli/",
-  "authCache": "authentication.json",
-  "translationCache": "translations.json"
-}

--- a/lib/output.js
+++ b/lib/output.js
@@ -1,11 +1,101 @@
 var __ = {};
 
 __.normal = function(content){
-  console.log(content);
+    console.log(content);
 }
 
-__.emphasis = function(content){
-  console.log(content.underline);
+__.bold = function(content){
+    console.log(content.bold);
+}
+
+__.italic = function(content){
+    console.log(content.italic);
+}
+
+__.underline = function(content){
+    console.log(content.underline);
+}
+
+__.inverse = function(content){
+    console.log(content.inverse);
+}
+
+__.strikethrough = function(content){
+    console.log(content.strikethrough);
+}
+
+__.white = function(content){
+    console.log(content.white);
+}
+
+__.grey = function(content){
+    console.log(content.grey);
+}
+__.gray = __.grey;
+
+__.black = function(content){
+    console.log(content.black);
+}
+
+__.blue = function(content){
+    console.log(content.blue);
+}
+
+__.cyan = function(content){
+    console.log(content.cyan);
+}
+
+__.green = function(content){
+    console.log(content.green);
+}
+
+__.magenta = function(content){
+    console.log(content.magenta);
+}
+
+__.red = function(content){
+    console.log(content.red);
+}
+
+__.yellow = function(content){
+    console.log(content.yellow);
+}
+
+__.whiteBG = function(content){
+    console.log(content.whiteBG);
+}
+
+__.greyBG = function(content){
+    console.log(content.greyBG);
+}
+__.grayBG = __.greyBG;
+
+__.blackBG = function(content){
+    console.log(content.blackBG);
+}
+
+__.blueBG = function(content){
+    console.log(content.blueBG);
+}
+
+__.cyanBG = function(content){
+    console.log(content.cyanBG);
+}
+
+__.greenBG = function(content){
+    console.log(content.greenBG);
+}
+
+__.magentaBG = function(content){
+    console.log(content.magentaBG);
+}
+
+__.redBG = function(content){
+    console.log(content.redBG);
+}
+
+__.yellowBG = function(content){
+    console.log(content.yellowBG);
 }
 
 module.exports = __;

--- a/src/authenticate.js
+++ b/src/authenticate.js
@@ -65,7 +65,7 @@ Auth.prototype.check = function(){
   if (!authCache.token){
     this.logger.debug("Token does not exist, asking the user to go via the web flow");
     this.output.normal("We couldn't find an authentication token! Please visit the following URL:");
-    this.output.emphasis(this.authenticationUrl);
+    this.output.underline(this.authenticationUrl);
     this.output.normal("Once you have a token, run the following command:");
     this.output.normal("trello set-auth <token>");
     process.exit(1);

--- a/src/authenticate.js
+++ b/src/authenticate.js
@@ -6,7 +6,7 @@ var Auth = function(logger, output, config){
   this.output = output;
   this.config = config;
 
-  this.authenticationUrl = "https://trello.com/1/connect?key="+this.config.get("appKey")+"&name=trello-cli&response_type=token&scope=read,write";
+  this.authenticationUrl = "https://trello.com/1/connect?key="+this.config.get("appKey")+"&name=trello-cli&response_type=token&scope=account,read,write&expiration=never";
 };
 
 Auth.prototype.loadAuthCache = function(){

--- a/src/commands/card-details.js
+++ b/src/commands/card-details.js
@@ -17,6 +17,7 @@ var __ = function(program, output, logger, config, trello, translator, trelloApi
         trello.get("/1/cards/" + cardId + "", {"fields": "all", "member_fields": "all"}, function(err, data) {
             if (err) throw err;
 
+            output.bold(translator.getList(data.idList) + " > " + data.name);
             output.normal(data);
         });
     }
@@ -27,8 +28,7 @@ var __ = function(program, output, logger, config, trello, translator, trelloApi
             .help("Show details about a specified card")
             .options({
                 "cardId": {
-                    abbr: 'c',
-                    metavar: 'CARD',
+                    position: 1,
                     help: "The short URL or ID of the card to display information about",
                     required: true
                 }

--- a/src/commands/card-details.js
+++ b/src/commands/card-details.js
@@ -1,0 +1,43 @@
+"use strict";
+
+fs = require("fs");
+
+var _ = require("underscore");
+
+var __ = function(program, output, logger, config, trello, translator, trelloApiCommands) {
+    logger.info("Showing lists belonging to the specified board");
+
+    var trelloApiCommand = {};
+
+    trelloApiCommand.makeTrelloApiCall = function (options, onComplete) {
+        logger.info("Showing details about the specified card");
+
+        var cardId = options.cardId.replace(/[https:\/\/|http:\/\/]*trello.com\/c\//gi, "");
+
+        trello.get("/1/cards/" + cardId + "", {"fields": "all", "member_fields": "all"}, function(err, data) {
+            if (err) throw err;
+
+            output.normal(data);
+        });
+    }
+
+    trelloApiCommand.nomnomProgramCall = function () {
+        program
+            .command("card-details")
+            .help("Show details about a specified card")
+            .options({
+                "cardId": {
+                    abbr: 'c',
+                    metavar: 'CARD',
+                    help: "The short URL or ID of the card to display information about",
+                    required: true
+                }
+            })
+            .callback(function (options) {
+                trelloApiCommand.makeTrelloApiCall(options);
+            });
+        }
+
+    return trelloApiCommand;
+}
+module.exports = __;

--- a/src/commands/show-cards.js
+++ b/src/commands/show-cards.js
@@ -42,10 +42,10 @@ var __ = function(program, output, logger, config, trello, translator, trelloApi
                 if (err) throw err;
 
                 if (data.cards.length > 0) {
-                    if (options.showListName) {
-                      output.normal(translator.getList(data.cards[0].idList).underline);
+                    if (options.showListName || !options.list) {
+                      output.underline(translator.getList(data.cards[0].idList));
                     } else {
-                      output.normal(translator.getBoard(data.cards[0].idBoard).underline);
+                      output.underline(translator.getBoard(data.cards[0].idBoard));
                     }
                 }
                 for (var i in data.cards) {
@@ -77,7 +77,7 @@ var __ = function(program, output, logger, config, trello, translator, trelloApi
                 },
                 "showListName": {
                       abbr: 'n',
-                      help: "Show list name in title, in addtion to board name",
+                      help: "Show list name in title, in addtion to board name, if specific list specified",
                       required: false,
                       flag: true,
                       default: true

--- a/src/commands/show-lists.js
+++ b/src/commands/show-lists.js
@@ -7,6 +7,7 @@ var __ = function (program, output, logger, config, trello, translator, trelloAp
     var trelloApiCommand = {};
 
     trelloApiCommand.makeTrelloApiCall = function (options, onComplete) {
+        logger.info("Showing lists belonging to the specified board");
 
         // Grab our boards etc
         if (options.board) {
@@ -52,13 +53,6 @@ var __ = function (program, output, logger, config, trello, translator, trelloAp
                     help: "The board name which contains the list of lists to show",
                     required: false
                 },
-                // "includeClosed": {
-                //       abbr: 'c',
-                //       help: "Include closed lists in the list (default: no)",
-                //       required: false,
-                //       flag: true,
-                //       default: false
-                // },
                 "hideIds": {
                       abbr: 'i',
                       help: "Do not include the list IDs in the output (default is to print IDs)",

--- a/src/commands/show-lists.js
+++ b/src/commands/show-lists.js
@@ -1,0 +1,78 @@
+"use strict";
+
+var _ = require("underscore");
+
+var __ = function (program, output, logger, config, trello, translator, trelloApiCommands) {
+
+    var trelloApiCommand = {};
+
+    trelloApiCommand.makeTrelloApiCall = function (options, onComplete) {
+
+        // Grab our boards etc
+        if (options.board) {
+            try {
+                var boardId = translator.getBoardIdByName(options.board);
+            } catch (err) {
+                if (err.message == "Unknown Board") {
+                    logger.warning("Unknown board.  Perhaps you have a typo?");
+
+                    output.normal("\nYou have the following open boards:\n");
+                    trelloApiCommands["show-boards"].makeTrelloApiCall({ includeClosed : false, hideIds : true}, null);
+                    return;
+                }
+            }
+        }
+
+        var listOfLists = [];
+
+        _.each(translator.cache.translations.lists, function (oneList, listId) {
+            if (listId != "undefined" && oneList.length == 2 && options.board ? oneList[0] == boardId : true) {
+                // oneList: [ boardId, listName ]
+                listOfLists.splice(
+                    _.sortedIndex(listOfLists, { id : listId, name : oneList[1] }, 'name'),
+                    0,
+                    { id : listId, name : oneList[1] });
+            }
+        });
+
+        _.each(listOfLists, function printBoardObject(list) {
+            output.normal(list.name + (options.hideIds ? "" : (" (ID: " + list.id + ")")));
+        });
+    };
+
+
+    trelloApiCommand.nomnomProgramCall = function () {
+        program
+            .command("show-lists")
+            .help("Show the list of cached lists")
+            .options({
+                "board": {
+                    abbr: 'b',
+                    metavar: 'BOARD',
+                    help: "The board name which contains the list of lists to show",
+                    required: false
+                },
+                // "includeClosed": {
+                //       abbr: 'c',
+                //       help: "Include closed lists in the list (default: no)",
+                //       required: false,
+                //       flag: true,
+                //       default: false
+                // },
+                "hideIds": {
+                      abbr: 'i',
+                      help: "Do not include the list IDs in the output (default is to print IDs)",
+                      required: false,
+                      flag: true,
+                      default: false
+                }
+            })
+            .callback(function (options) {
+                trelloApiCommand.makeTrelloApiCall(options);
+            });
+    };
+
+    return trelloApiCommand;
+}
+
+module.exports = __;

--- a/src/node-trello-wrapper.js
+++ b/src/node-trello-wrapper.js
@@ -29,7 +29,7 @@ var __ = function (output, logger, config, authentication) {
     trelloWrapper.callbackWrapperFactory = function (callback) {
         return function (err, data) {
             if (data == "expired token" || data == "invalid token") {
-                logger.error("Authentication token has expired.");
+                logger.error("Authentication token has expired or is otherwise invalid.");
                 output.normal("To get a new token, please re-visit:");
                 output.emphasis(authentication.authenticationUrl);
                 output.normal("Once you have a token, run the following command:");

--- a/src/node-trello-wrapper.js
+++ b/src/node-trello-wrapper.js
@@ -31,7 +31,7 @@ var __ = function (output, logger, config, authentication) {
             if (data == "expired token" || data == "invalid token") {
                 logger.error("Authentication token has expired or is otherwise invalid.");
                 output.normal("To get a new token, please re-visit:");
-                output.emphasis(authentication.authenticationUrl);
+                output.underline(authentication.authenticationUrl);
                 output.normal("Once you have a token, run the following command:");
                 output.normal("trello set-auth <token>");
                 process.exit(1);


### PR DESCRIPTION
The show-cards command requires the list name to be passed in, as well as the board name.  However, we have no way of knowing the lists that are a part of a board, at least not without leaving the CLI.  This pull request adds a command that shows all of the lists, or all of the lists in a specified board.  This also removes the list argument requirement in the show-cards command, and will list all cards in a board if the list argument is unspecified.