### PR TITLE
fix code that creates new translation cache file

### DIFF
--- a/bin/trello
+++ b/bin/trello
@@ -80,7 +80,7 @@ var trelloApiCommands = registerCommands();
 
 if (process.argv[2] == 'set-auth' || !translator.checkCompatibleCache) {
     logger.warning("Cache file is not compatible with this version, trying to create new one.");
-    translator.refreshTranslations("all");
+    translator.reloadTranslations("all");
 }
 
 


### PR DESCRIPTION
I was getting this:

```
warning: Cache file is not compatible with this version, trying to create new one.
/usr/lib/node_modules/trello-cli/bin/trello:83
    translator.refreshTranslations("all");
               ^

TypeError: translator.refreshTranslations is not a function
    at Object.<anonymous> (/usr/lib/node_modules/trello-cli/bin/trello:83:16)
    at Module._compile (module.js:571:32)
    at Object.Module._extensions..js (module.js:580:10)
    at Module.load (module.js:488:32)
    at tryModuleLoad (module.js:447:12)
    at Function.Module._load (module.js:439:3)
    at Module.runMain (module.js:605:10)
    at run (bootstrap_node.js:420:7)
    at startup (bootstrap_node.js:139:9)
    at bootstrap_node.js:535:3
```

turns out the function had been renamed.