### PR TITLE
Fix refresh rate limits

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "trello-cli",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -178,6 +178,11 @@
         "hoek": "2.16.3"
       }
     },
+    "bottleneck": {
+      "version": "2.18.1",
+      "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.18.1.tgz",
+      "integrity": "sha512-EhSYARs0MHsNRBPrp1TaeHpgmWFUpA6yl3NNBPjGNilBaQZr4iSbrJ16JbQVXuZkIaB7YVYfaiMiRq7NgyZFQg=="
+    },
     "brace-expansion": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
@@ -289,9 +294,9 @@
       }
     },
     "commander": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -856,7 +861,7 @@
       "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
       "requires": {
         "chalk": "1.1.3",
-        "commander": "2.11.0",
+        "commander": "2.20.0",
         "is-my-json-valid": "2.16.1",
         "pinkie-promise": "2.0.1"
       }
@@ -1168,6 +1173,14 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.4.tgz",
       "integrity": "sha512-XCpr5bElgDI65vVgstP8TWjv6/QKWm9GU5UG0Pr5sLQ3QLo8NVKsioe+Jed5/3vFOe3IQuqE7DKwTvKQkjTHvg=="
+    },
+    "local-credentials": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/local-credentials/-/local-credentials-0.0.2.tgz",
+      "integrity": "sha512-26wAOBzxR2RKS3Oudhk/jHE1bmvIn6C61AGV8OyQaD5julwXv6nrZbdaRhGKHLVSdr2dRPO31mOjpX0AHGQXjQ==",
+      "requires": {
+        "ini": "1.3.5"
+      }
     },
     "lodash": {
       "version": "4.17.4",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "dependencies": {
     "async": "~0.2.9",
+    "bottleneck": "^2.18.1",
     "colors": "~0.6.2",
     "limiter": "^1.1.0",
     "nconf": "~0.6.7",


### PR DESCRIPTION
Instead of using the `/members` endpoint and fetching each person individually, use the `/boards/:id/members` subresource to fetch them all at once.

This PR also swaps `limiter` for `Bottleneck` and adds better rate limit handling and warnings

Resolves #50 