### PR TITLE
Allow authentication via environment

### DIFF
--- a/.changeset/pink-dryers-divide.md
+++ b/.changeset/pink-dryers-divide.md
@@ -1,0 +1,6 @@
+---
+"@trello-cli/config": minor
+"@trello-cli/cache": patch
+---
+
+Add support for TRELLO_API_KEY and TRELLO_TOKEN

--- a/packages/cache/src/db.ts
+++ b/packages/cache/src/db.ts
@@ -1,10 +1,14 @@
 import Database from "better-sqlite3";
 import path from "path";
+import fs from "fs";
 
 class DB {
   protected db: Database.Database;
 
   constructor(configDir: string, dbName: string) {
+    if (!fs.existsSync(configDir)) {
+      fs.mkdirSync(configDir, { recursive: true });
+    }
     this.db = new Database(path.join(configDir, `${dbName}.db`));
   }
 

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -13,6 +13,10 @@ class Config {
 
   // Getters + Setters
   async getApiKey() {
+    if (process.env.TRELLO_API_KEY) {
+      return process.env.TRELLO_API_KEY;
+    }
+
     try {
       return await this.getConfigKey("apiKey");
     } catch (e: any) {
@@ -33,6 +37,10 @@ class Config {
   }
 
   async getToken(): Promise<string> {
+    if (process.env.TRELLO_TOKEN) {
+      return process.env.TRELLO_TOKEN;
+    }
+
     try {
       return await this.getConfigKey("token");
     } catch (e: any) {

--- a/packages/trello-cli/README.md
+++ b/packages/trello-cli/README.md
@@ -1,0 +1,6 @@
+## Authentication
+
+`trello-cli` can be configured in two ways:
+
+1. Using `~/.trello-cli/<profile>/config.json`. Running the CLI explains how to generate tokens and will automatically create this file
+2. Using the `TRELLO_TOKEN` and `TRELLO_API_KEY` environment variables. It is recommended to use option 1 to fetch these values, then set the environment variables and delete `config.json` if required.


### PR DESCRIPTION
Allows the user to set `TRELLO_API_KEY` and `TRELLO_TOKEN` to authenticate requests without writing a configuration file

Resolves #61