### PR TITLE
feat: add `notification` command group

### DIFF
--- a/.changeset/notification-commands.md
+++ b/.changeset/notification-commands.md
@@ -1,0 +1,5 @@
+---
+"trello-cli": minor
+---
+
+Add a `notification` command group for managing Trello notifications: `notification:list` (list your notifications), `notification:show` (show a single notification), `notification:read` and `notification:unread` (mark a notification read/unread), and `notification:read-all` (mark all as read).

--- a/packages/trello-cli/src/commands/notification/index.ts
+++ b/packages/trello-cli/src/commands/notification/index.ts
@@ -1,0 +1,5 @@
+import { BaseCommand } from "../../BaseCommand";
+
+export default class NotificationIndex extends BaseCommand<typeof NotificationIndex> {
+  static description = "Notification related commands";
+}

--- a/packages/trello-cli/src/commands/notification/list.ts
+++ b/packages/trello-cli/src/commands/notification/list.ts
@@ -1,0 +1,49 @@
+import { BaseCommand } from "../../BaseCommand";
+import { Flags } from "@oclif/core";
+
+export default class NotificationList extends BaseCommand<typeof NotificationList> {
+  static description = "List your notifications";
+
+  protected defaultOutput = "fancy" as const;
+
+  static flags = {
+    filter: Flags.option({
+      options: ["all", "read", "unread"] as const,
+      default: "all",
+    })(),
+    limit: Flags.integer({ default: 50 }),
+  };
+
+  async run(): Promise<void> {
+    const notifications = await this.client.members.getMemberNotifications({
+      id: "me",
+      readFilter: this.flags.filter,
+      limit: this.flags.limit,
+      memberCreator: true,
+    });
+    this.output(notifications);
+  }
+
+  protected toData(data: any) {
+    return data.map((n: any) => ({
+      id: n.id,
+      type: n.type,
+      unread: n.unread,
+      date: n.date,
+      creator: n.memberCreator?.fullName,
+      summary: n.data?.text || n.data?.card?.name || n.data?.board?.name || "",
+    }));
+  }
+
+  protected async format(data: any): Promise<string> {
+    if (data.length === 0) {
+      return "No notifications";
+    }
+    return data
+      .map((n: any) => {
+        const status = n.unread ? "[unread]" : "[read]  ";
+        return `${status} ${n.date} ${n.type} - ${n.creator ?? ""}: ${n.summary} (id: ${n.id})`;
+      })
+      .join("\n");
+  }
+}

--- a/packages/trello-cli/src/commands/notification/read-all.ts
+++ b/packages/trello-cli/src/commands/notification/read-all.ts
@@ -1,0 +1,10 @@
+import { BaseCommand } from "../../BaseCommand";
+
+export default class NotificationReadAll extends BaseCommand<typeof NotificationReadAll> {
+  static description = "Mark all notifications as read";
+
+  async run(): Promise<void> {
+    const result = await this.client.notifications.markAllNotificationsAsRead();
+    this.output(result);
+  }
+}

--- a/packages/trello-cli/src/commands/notification/read.ts
+++ b/packages/trello-cli/src/commands/notification/read.ts
@@ -1,0 +1,18 @@
+import { BaseCommand } from "../../BaseCommand";
+import { Flags } from "@oclif/core";
+
+export default class NotificationRead extends BaseCommand<typeof NotificationRead> {
+  static description = "Mark a notification as read";
+
+  static flags = {
+    id: Flags.string({ required: true }),
+  };
+
+  async run(): Promise<void> {
+    const result = await this.client.notifications.updateNotification({
+      id: this.flags.id,
+      unread: false,
+    });
+    this.output(result);
+  }
+}

--- a/packages/trello-cli/src/commands/notification/show.ts
+++ b/packages/trello-cli/src/commands/notification/show.ts
@@ -1,0 +1,47 @@
+import { BaseCommand } from "../../BaseCommand";
+import { Flags } from "@oclif/core";
+
+export default class NotificationShow extends BaseCommand<typeof NotificationShow> {
+  static description = "Show a single notification";
+
+  protected defaultOutput = "fancy" as const;
+
+  static flags = {
+    id: Flags.string({ required: true }),
+  };
+
+  async run(): Promise<void> {
+    const notification = await this.client.notifications.getNotification({
+      id: this.flags.id,
+      board: true,
+      card: true,
+      memberCreator: true,
+    });
+    this.output(notification);
+  }
+
+  protected toData(data: any) {
+    return {
+      id: data.id,
+      type: data.type,
+      unread: data.unread,
+      date: data.date,
+      creator: data.memberCreator?.fullName,
+      board: data.board?.name,
+      card: data.card?.name,
+      data: data.data,
+    };
+  }
+
+  protected async format(data: any): Promise<string> {
+    return [
+      `ID:      ${data.id}`,
+      `Type:    ${data.type}`,
+      `Unread:  ${data.unread}`,
+      `Date:    ${data.date}`,
+      `Creator: ${data.creator ?? ""}`,
+      `Board:   ${data.board ?? ""}`,
+      `Card:    ${data.card ?? ""}`,
+    ].join("\n");
+  }
+}

--- a/packages/trello-cli/src/commands/notification/unread.ts
+++ b/packages/trello-cli/src/commands/notification/unread.ts
@@ -1,0 +1,18 @@
+import { BaseCommand } from "../../BaseCommand";
+import { Flags } from "@oclif/core";
+
+export default class NotificationUnread extends BaseCommand<typeof NotificationUnread> {
+  static description = "Mark a notification as unread";
+
+  static flags = {
+    id: Flags.string({ required: true }),
+  };
+
+  async run(): Promise<void> {
+    const result = await this.client.notifications.updateNotification({
+      id: this.flags.id,
+      unread: true,
+    });
+    this.output(result);
+  }
+}

--- a/packages/trello-cli/test/commands/notification/list.test.ts
+++ b/packages/trello-cli/test/commands/notification/list.test.ts
@@ -1,0 +1,104 @@
+import { runCommand } from "@oclif/test";
+import Config from "@trello-cli/config";
+import { ux } from "@oclif/core";
+
+const mockNotifications = [
+  {
+    id: "notif1",
+    type: "mentionedOnCard",
+    unread: true,
+    date: "2026-06-01T10:00:00.000Z",
+    memberCreator: { fullName: "John Doe" },
+    data: { card: { name: "Fix login bug" }, board: { name: "Backend" }, text: "" },
+  },
+  {
+    id: "notif2",
+    type: "commentCard",
+    unread: false,
+    date: "2026-06-02T12:00:00.000Z",
+    memberCreator: { fullName: "Jane Smith" },
+    data: { text: "Please review", card: { name: "Add tests" } },
+  },
+];
+
+const getMemberNotifications = jest.fn().mockResolvedValue(mockNotifications);
+
+jest.mock("trello.js", () => ({
+  TrelloClient: jest.fn().mockImplementation(() => ({
+    members: { getMemberNotifications },
+  })),
+}));
+
+jest.mock("@trello-cli/cache", () => {
+  return {
+    __esModule: true,
+    default: jest.fn().mockImplementation(() => ({})),
+  };
+});
+
+let stdoutSpy: jest.SpyInstance;
+
+beforeEach(() => {
+  jest
+    .spyOn(Config.prototype, "getToken")
+    .mockImplementation(() => Promise.resolve("fake_token"));
+  jest
+    .spyOn(Config.prototype, "getApiKey")
+    .mockImplementation(() => Promise.resolve("fake_api_key"));
+
+  stdoutSpy = jest.spyOn(ux, "stdout").mockImplementation(() => {});
+
+  getMemberNotifications.mockClear();
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("notification:list", () => {
+  it("calls getMemberNotifications with default params", async () => {
+    const { error } = await runCommand(["notification:list", "--format", "json"]);
+    expect(error).toBeUndefined();
+    expect(getMemberNotifications).toHaveBeenCalledTimes(1);
+    expect(getMemberNotifications).toHaveBeenCalledWith({
+      id: "me",
+      readFilter: "all",
+      limit: 50,
+      memberCreator: true,
+    });
+  });
+
+  it("passes filter and limit flags through", async () => {
+    await runCommand([
+      "notification:list",
+      "--filter", "unread",
+      "--limit", "10",
+      "--format", "json",
+    ]);
+    expect(getMemberNotifications).toHaveBeenCalledWith({
+      id: "me",
+      readFilter: "unread",
+      limit: 10,
+      memberCreator: true,
+    });
+  });
+
+  it("outputs correct JSON shape", async () => {
+    await runCommand(["notification:list", "--format", "json"]);
+    const output = JSON.parse(stdoutSpy.mock.calls[0][0]);
+    expect(output).toHaveLength(2);
+    expect(output[0].id).toBe("notif1");
+    expect(output[0].type).toBe("mentionedOnCard");
+    expect(output[0].unread).toBe(true);
+    expect(output[0].creator).toBe("John Doe");
+    expect(output[0].summary).toBe("Fix login bug");
+    expect(output[1].summary).toBe("Please review");
+  });
+
+  it("handles empty notifications array", async () => {
+    getMemberNotifications.mockResolvedValueOnce([]);
+    await runCommand(["notification:list", "--format", "json"]);
+    const output = JSON.parse(stdoutSpy.mock.calls[0][0]);
+    expect(output).toHaveLength(0);
+  });
+});

--- a/packages/trello-cli/test/commands/notification/read-all.test.ts
+++ b/packages/trello-cli/test/commands/notification/read-all.test.ts
@@ -1,0 +1,40 @@
+import { runCommand } from "@oclif/test";
+import Config from "@trello-cli/config";
+
+const markAllNotificationsAsRead = jest.fn().mockResolvedValue(undefined);
+
+jest.mock("trello.js", () => ({
+  TrelloClient: jest.fn().mockImplementation(() => ({
+    notifications: { markAllNotificationsAsRead },
+  })),
+}));
+
+jest.mock("@trello-cli/cache", () => {
+  return {
+    __esModule: true,
+    default: jest.fn().mockImplementation(() => ({})),
+  };
+});
+
+beforeEach(() => {
+  jest
+    .spyOn(Config.prototype, "getToken")
+    .mockImplementation(() => Promise.resolve("fake_token"));
+  jest
+    .spyOn(Config.prototype, "getApiKey")
+    .mockImplementation(() => Promise.resolve("fake_api_key"));
+
+  markAllNotificationsAsRead.mockClear();
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("notification:read-all", () => {
+  it("calls markAllNotificationsAsRead once", async () => {
+    const { error } = await runCommand(["notification:read-all"]);
+    expect(error).toBeUndefined();
+    expect(markAllNotificationsAsRead).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/trello-cli/test/commands/notification/read.test.ts
+++ b/packages/trello-cli/test/commands/notification/read.test.ts
@@ -1,0 +1,54 @@
+import { runCommand } from "@oclif/test";
+import Config from "@trello-cli/config";
+
+const updateNotification = jest
+  .fn()
+  .mockResolvedValue({ id: "notif1", unread: false });
+
+jest.mock("trello.js", () => ({
+  TrelloClient: jest.fn().mockImplementation(() => ({
+    notifications: { updateNotification },
+  })),
+}));
+
+jest.mock("@trello-cli/cache", () => {
+  return {
+    __esModule: true,
+    default: jest.fn().mockImplementation(() => ({})),
+  };
+});
+
+beforeEach(() => {
+  jest
+    .spyOn(Config.prototype, "getToken")
+    .mockImplementation(() => Promise.resolve("fake_token"));
+  jest
+    .spyOn(Config.prototype, "getApiKey")
+    .mockImplementation(() => Promise.resolve("fake_api_key"));
+
+  updateNotification.mockClear();
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("notification:read", () => {
+  it("throws when --id flag is missing", async () => {
+    const { error } = await runCommand(["notification:read"]);
+    expect(error?.message).toContain("Missing required flag");
+  });
+
+  it("calls updateNotification with unread false", async () => {
+    const { error } = await runCommand([
+      "notification:read",
+      "--id", "notif1",
+    ]);
+    expect(error).toBeUndefined();
+    expect(updateNotification).toHaveBeenCalledTimes(1);
+    expect(updateNotification).toHaveBeenCalledWith({
+      id: "notif1",
+      unread: false,
+    });
+  });
+});

--- a/packages/trello-cli/test/commands/notification/show.test.ts
+++ b/packages/trello-cli/test/commands/notification/show.test.ts
@@ -1,0 +1,84 @@
+import { runCommand } from "@oclif/test";
+import Config from "@trello-cli/config";
+import { ux } from "@oclif/core";
+
+const mockNotification = {
+  id: "notif1",
+  type: "mentionedOnCard",
+  unread: true,
+  date: "2026-06-01T10:00:00.000Z",
+  memberCreator: { fullName: "John Doe" },
+  board: { name: "Backend" },
+  card: { name: "Fix login bug" },
+  data: { text: "hey @me" },
+};
+
+const getNotification = jest.fn().mockResolvedValue(mockNotification);
+
+jest.mock("trello.js", () => ({
+  TrelloClient: jest.fn().mockImplementation(() => ({
+    notifications: { getNotification },
+  })),
+}));
+
+jest.mock("@trello-cli/cache", () => {
+  return {
+    __esModule: true,
+    default: jest.fn().mockImplementation(() => ({})),
+  };
+});
+
+let stdoutSpy: jest.SpyInstance;
+
+beforeEach(() => {
+  jest
+    .spyOn(Config.prototype, "getToken")
+    .mockImplementation(() => Promise.resolve("fake_token"));
+  jest
+    .spyOn(Config.prototype, "getApiKey")
+    .mockImplementation(() => Promise.resolve("fake_api_key"));
+
+  stdoutSpy = jest.spyOn(ux, "stdout").mockImplementation(() => {});
+
+  getNotification.mockClear();
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("notification:show", () => {
+  it("throws when --id flag is missing", async () => {
+    const { error } = await runCommand(["notification:show"]);
+    expect(error?.message).toContain("Missing required flag");
+  });
+
+  it("calls getNotification with correct params", async () => {
+    const { error } = await runCommand([
+      "notification:show",
+      "--id", "notif1",
+      "--format", "json",
+    ]);
+    expect(error).toBeUndefined();
+    expect(getNotification).toHaveBeenCalledTimes(1);
+    expect(getNotification).toHaveBeenCalledWith({
+      id: "notif1",
+      board: true,
+      card: true,
+      memberCreator: true,
+    });
+  });
+
+  it("outputs correct JSON shape", async () => {
+    await runCommand([
+      "notification:show",
+      "--id", "notif1",
+      "--format", "json",
+    ]);
+    const output = JSON.parse(stdoutSpy.mock.calls[0][0]);
+    expect(output.id).toBe("notif1");
+    expect(output.creator).toBe("John Doe");
+    expect(output.board).toBe("Backend");
+    expect(output.card).toBe("Fix login bug");
+  });
+});

--- a/packages/trello-cli/test/commands/notification/unread.test.ts
+++ b/packages/trello-cli/test/commands/notification/unread.test.ts
@@ -1,0 +1,54 @@
+import { runCommand } from "@oclif/test";
+import Config from "@trello-cli/config";
+
+const updateNotification = jest
+  .fn()
+  .mockResolvedValue({ id: "notif1", unread: true });
+
+jest.mock("trello.js", () => ({
+  TrelloClient: jest.fn().mockImplementation(() => ({
+    notifications: { updateNotification },
+  })),
+}));
+
+jest.mock("@trello-cli/cache", () => {
+  return {
+    __esModule: true,
+    default: jest.fn().mockImplementation(() => ({})),
+  };
+});
+
+beforeEach(() => {
+  jest
+    .spyOn(Config.prototype, "getToken")
+    .mockImplementation(() => Promise.resolve("fake_token"));
+  jest
+    .spyOn(Config.prototype, "getApiKey")
+    .mockImplementation(() => Promise.resolve("fake_api_key"));
+
+  updateNotification.mockClear();
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("notification:unread", () => {
+  it("throws when --id flag is missing", async () => {
+    const { error } = await runCommand(["notification:unread"]);
+    expect(error?.message).toContain("Missing required flag");
+  });
+
+  it("calls updateNotification with unread true", async () => {
+    const { error } = await runCommand([
+      "notification:unread",
+      "--id", "notif1",
+    ]);
+    expect(error).toBeUndefined();
+    expect(updateNotification).toHaveBeenCalledTimes(1);
+    expect(updateNotification).toHaveBeenCalledWith({
+      id: "notif1",
+      unread: true,
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,7 +40,7 @@ importers:
     dependencies:
       better-sqlite3:
         specifier: ^12.6.2
-        version: 12.6.2
+        version: 12.11.1
     devDependencies:
       '@types/better-sqlite3':
         specifier: ^7.6.8
@@ -1569,9 +1569,9 @@ packages:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
 
-  better-sqlite3@12.6.2:
-    resolution: {integrity: sha512-8VYKM3MjCa9WcaSAI3hzwhmyHVlH8tiGFwf0RlTsZPWJ1I5MkzjiudCo4KC4DxOaL/53A5B1sI/IbldNFDbsKA==}
-    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x}
+  better-sqlite3@12.11.1:
+    resolution: {integrity: sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==}
+    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x || 26.x}
 
   bindings@1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
@@ -3015,6 +3015,7 @@ packages:
   prebuild-install@7.1.3:
     resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
     engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
     hasBin: true
 
   prelude-ls@1.2.1:
@@ -5804,7 +5805,7 @@ snapshots:
     dependencies:
       is-windows: 1.0.2
 
-  better-sqlite3@12.6.2:
+  better-sqlite3@12.11.1:
     dependencies:
       bindings: 1.5.0
       prebuild-install: 7.1.3


### PR DESCRIPTION
#236

## What

Adds a `notification` command group for managing Trello notifications:

- `notification:list` — list your notifications (`--filter all|read|unread`, `--limit`)
- `notification:show` — show a single notification (`--id`)
- `notification:read` and `notification:unread` — mark a notification read/unread (`--id`)
- `notification:read-all` — mark all notifications as read

## Why

The CLI had no notification commands, even though the underlying `trello.js` client already supports the endpoints (`members.getMemberNotifications`, `notifications.getNotification`, `notifications.updateNotification`, `notifications.markAllNotificationsAsRead`). See #236 for the full motivation and repo context.

## Implementation notes

- Each command is a thin `BaseCommand` subclass following existing patterns (for example `card/label.ts` and `board/members.ts`). No `package.json` changes are needed because oclif auto-discovers commands. `read` and `unread` are separate paired commands to match the repo's existing convention (such as `label`/`unlabel` and `assign`/`unassign`).
- Tests are added for every command using `@oclif/test` with `trello.js` and the cache mocked; the full suite passes (298 tests).
- Includes a changeset (minor).
- Also bumps `better-sqlite3` to 12.11.1 (within the existing `^12.6.2` range) so the workspace builds on Node 26 — the lockfile previously pinned 12.6.2, which fails to compile on Node 26.

Closes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)
